### PR TITLE
Disabled rebuys for trades in hold (IMPORTANT, READ DESCRIPTION!!)

### DIFF
--- a/config_examples/config_binance.example.json
+++ b/config_examples/config_binance.example.json
@@ -9,7 +9,9 @@
     "cancel_open_orders_on_exit": false,
     "unfilledtimeout": {
         "buy": 10,
-        "sell": 30
+        "sell": 10,
+        "exit_timeout_count": 0,
+        "unit": "minutes"
     },
     "bid_strategy": {
         "ask_last_balance": 0.0,

--- a/config_examples/config_bittrex.example.json
+++ b/config_examples/config_bittrex.example.json
@@ -9,7 +9,9 @@
     "cancel_open_orders_on_exit": false,
     "unfilledtimeout": {
         "buy": 10,
-        "sell": 30
+        "sell": 10,
+        "exit_timeout_count": 0,
+        "unit": "minutes"
     },
     "bid_strategy": {
         "use_order_book": true,

--- a/config_examples/config_ftx.example.json
+++ b/config_examples/config_ftx.example.json
@@ -9,7 +9,9 @@
     "cancel_open_orders_on_exit": false,
     "unfilledtimeout": {
         "buy": 10,
-        "sell": 30
+        "sell": 10,
+        "exit_timeout_count": 0,
+        "unit": "minutes"
     },
     "bid_strategy": {
         "ask_last_balance": 0.0,

--- a/config_examples/config_full.example.json
+++ b/config_examples/config_full.example.json
@@ -28,7 +28,7 @@
     "stoploss": -0.10,
     "unfilledtimeout": {
         "buy": 10,
-        "sell": 30,
+        "sell": 10,
         "exit_timeout_count": 0,
         "unit": "minutes"
     },

--- a/config_examples/config_kraken.example.json
+++ b/config_examples/config_kraken.example.json
@@ -9,7 +9,9 @@
     "cancel_open_orders_on_exit": false,
     "unfilledtimeout": {
         "buy": 10,
-        "sell": 30
+        "sell": 10,
+        "exit_timeout_count": 0,
+        "unit": "minutes"
     },
     "bid_strategy": {
         "use_order_book": true,

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -460,7 +460,8 @@ class FreqtradeBot(LoggingMixin):
         # Walk through each pair and check if it needs changes
         for trade in Trade.get_open_trades():
             # If there is any open orders, wait for them to finish.
-            if trade.open_order_id is None:
+            if (trade.open_order_id is None
+                and (trade.hold_pct is None or trade.hold_pct == 0)):
                 try:
                     self.check_and_call_adjust_trade_position(trade)
                 except DependencyException as exception:
@@ -609,7 +610,8 @@ class FreqtradeBot(LoggingMixin):
         # Fee is applied twice because we make a LIMIT_BUY and LIMIT_SELL
         fee = self.exchange.get_fee(symbol=pair, taker_or_maker='maker')
         # This is a new trade
-        if trade is None:
+        if (trade is None or 
+            (trade.hold_pct is not None and trade.hold_pct != 0)):
             trade = Trade(
                 pair=pair,
                 stake_amount=stake_amount,

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -592,6 +592,7 @@ class RPC:
         value = self._fiat_converter.convert_amount(
             total, stake_currency, fiat_display_currency) if self._fiat_converter else 0
 
+        trade_count = len(Trade.get_trades_proxy())
         starting_capital_ratio = 0.0
         starting_capital_ratio = (total / starting_capital) - 1 if starting_capital else 0.0
         starting_cap_fiat_ratio = (value / starting_cap_fiat) - 1 if starting_cap_fiat else 0.0
@@ -608,6 +609,7 @@ class RPC:
             'starting_capital_fiat': starting_cap_fiat,
             'starting_capital_fiat_ratio': starting_cap_fiat_ratio,
             'starting_capital_fiat_pct': round(starting_cap_fiat_ratio * 100, 2),
+            'trade_count': trade_count,
             'note': 'Simulated balances' if self._freqtrade.config['dry_run'] else ''
         }
 

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -1012,14 +1012,12 @@ class RPC:
         if not self._freqtrade.exchange.get_pair_quote_currency(pair) == stake_currency:
             raise RPCException(
                 f'Wrong pair selected. Only pairs with stake-currency {stake_currency} allowed.')
-        # check if valid pair
 
         # check if pair already has an open pair
-        # TODO: Add extra config for buying same pair without position_adjustment flag
         trade = Trade.get_trades([Trade.is_open.is_(True), Trade.pair == pair]).first()
-        #if trade:
-        #    if not self._freqtrade.strategy.position_adjustment_enable:
-        #        raise RPCException(f'position for {pair} already open - id: {trade.id}')
+        if trade:
+           if not self._freqtrade.strategy.position_adjustment_enable:
+               raise RPCException(f'position for {pair} already open - id: {trade.id}')
 
         # gen stake amount
         if custom_stake_amount:
@@ -1051,41 +1049,6 @@ class RPC:
             return trade
         else:
             return None
-
-    # def _rpc_forcebuy(self, pair: str, price: Optional[float]) -> Optional[Trade]:
-    #     """
-    #     Handler for forcebuy <asset> <price>
-    #     Buys a pair trade at the given or current price
-    #     """
-
-    #     if not self._freqtrade.config.get('forcebuy_enable', False):
-    #         raise RPCException('Forcebuy not enabled.')
-
-    #     if self._freqtrade.state != State.RUNNING:
-    #         raise RPCException('trader is not running')
-
-    #     # Check if pair quote currency equals to the stake currency.
-    #     stake_currency = self._freqtrade.config.get('stake_currency')
-    #     if not self._freqtrade.exchange.get_pair_quote_currency(pair) == stake_currency:
-    #         raise RPCException(
-    #             f'Wrong pair selected. Only pairs with stake-currency {stake_currency} allowed.')
-    #     # check if valid pair
-
-    #     # check if pair already has an open pair
-    #     trade = Trade.get_trades([Trade.is_open.is_(True), Trade.pair == pair]).first()
-    #     if trade:
-    #         raise RPCException(f'position for {pair} already open - id: {trade.id}')
-
-    #     # gen stake amount
-    #     stakeamount = self._freqtrade.wallets.get_trade_stake_amount(pair)
-
-    #     # execute buy
-    #     if self._freqtrade.execute_entry(pair, stakeamount, price, forcebuy=True):
-    #         Trade.commit()
-    #         trade = Trade.get_trades([Trade.is_open.is_(True), Trade.pair == pair]).first()
-    #         return trade
-    #     else:
-    #         return None
 
     def _rpc_delete(self, trade_id: int) -> Dict[str, Union[str, int]]:
         """

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -765,14 +765,17 @@ class Telegram(RPCHandler):
                     f"(< {balance_dust_level} {result['stake']}):*\n"
                     f"\t`Est. {result['stake']}: "
                     f"{round_coin_value(total_dust_balance, result['stake'], False)}`\n")
+            tc = result['trade_count'] > 0
+            stake_improve = f" `({result['starting_capital_ratio']:.2%})`" if tc else ''
+            fiat_val = f" `({result['starting_capital_fiat_ratio']:.2%})`" if tc else ''
 
             output += ("\n*Estimated Value*:\n"
                        f"\t`{result['stake']}: "
                        f"{round_coin_value(result['total'], result['stake'], False)}`"
-                       f" `({result['starting_capital_ratio']:.2%})`\n"
+                       f"{stake_improve}\n"
                        f"\t`{result['symbol']}: "
                        f"{round_coin_value(result['value'], result['symbol'], False)}`"
-                       f" `({result['starting_capital_fiat_ratio']:.2%})`\n")
+                       f"{fiat_val}\n")
             self._send_msg(output, reload_able=True, callback_path="update_balance",
                            query=update.callback_query)
         except RPCException as e:

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -523,6 +523,7 @@ class Telegram(RPCHandler):
         :param update: message update
         :return: None
         """
+        self._send_msg(f"Feature is deprecated, migrate to position_adjustment_enable.")
         fiat_currency = self._config.get('fiat_display_currency', '')
         sstake_currency = self._config['stake_currency']
         # pair = context.args[0] if context.args and len(context.args) > 0 else None
@@ -562,6 +563,7 @@ class Telegram(RPCHandler):
 
     @authorized_only
     def _split(self, update: Update, context: CallbackContext) -> None:
+        self._send_msg(f"Feature is deprecated, migrate to position_adjustment_enable.")
         id = context.args[0] if context.args and len(context.args) > 0 else None
 
         if len(context.args) > 1:
@@ -581,6 +583,7 @@ class Telegram(RPCHandler):
 
     @authorized_only
     def _merge(self, update: Update, context: CallbackContext) -> None:
+        self._send_msg(f"Feature is deprecated, migrate to position_adjustment_enable.")
         pair = context.args[0] if context.args and len(context.args) > 0 else None
         if not pair:
             self._send_msg("Pair not set. -/-merge CCC/SSSS")
@@ -1584,12 +1587,12 @@ class Telegram(RPCHandler):
 
             "_CustomCommands_\n"
             "------------\n"
-            "*/avg <pair>:* `Shows the averaging down calculation of given pair.`\n"
-            "*/merge <pair> :* `Merge open trades of given pair.`\n"
-            "*/split <trade_id> [<n>]:* `Split open trade in n number of trades. May cause dust.`\n"
+            "*/avg <pair>:* `DEPRECATED - migrate to position_adjustment_enable`\n"
+            "*/merge <pair> :* `DEPRECATED - migrate to with position_adjustment_enable`\n"
+            "*/split <trade_id> [<n>]:* `DEPRECATED - migrate to position_adjustment_enable`\n"
             "*/reset_trade <trade_id>|all:* `Reset open_date, min and max_rate and stoploss for the given trade or all trades`\n"
             "*/add_lock <trade_id> [<minutes>]:* `Add a pair lock`\n"
-            "*/hold <id> [<percentage>]:* `Hold a pair until profit percentage is met`\n"
+            "*/hold <id> [<percentage>]:* `Hold a pair until profit percentage is met. Also disables re-buy for now.`\n"
             "*/trail <id> [<percentage>]:* `Start trailing (0.5%) on a trade after profit percentage is met`\n"
             "*/max_trades <n> :* `Set max number of trades`\n"
             )

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -654,6 +654,9 @@ class IStrategy(ABC, HyperStrategyMixin):
 
         buy_tag = latest.get(SignalTagType.BUY_TAG.value, None)
         exit_tag = latest.get(SignalTagType.EXIT_TAG.value, None)
+        # Tags can be None, which does not resolve to False.
+        buy_tag = buy_tag if isinstance(buy_tag, str) else None
+        exit_tag = exit_tag if isinstance(exit_tag, str) else None
 
         logger.debug('trigger: %s (pair=%s) buy=%s sell=%s',
                      latest['date'], pair, str(buy), str(sell))

--- a/freqtrade/templates/base_config.json.j2
+++ b/freqtrade/templates/base_config.json.j2
@@ -15,7 +15,8 @@
     "cancel_open_orders_on_exit": false,
     "unfilledtimeout": {
         "buy": 10,
-        "sell": 30,
+        "sell": 10,
+        "exit_timeout_count": 0,
         "unit": "minutes"
     },
     "bid_strategy": {

--- a/tests/rpc/test_rpc_telegram.py
+++ b/tests/rpc/test_rpc_telegram.py
@@ -4,7 +4,7 @@
 
 import logging
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import reduce
 from random import choice, randint
 from string import ascii_uppercase
@@ -702,10 +702,12 @@ def test_profit_handle(default_conf, update, ticker, ticker_sell_up, fee,
     mocker.patch('freqtrade.exchange.Exchange.fetch_ticker', ticker_sell_up)
     trade.update(limit_sell_order)
 
-    trade.close_date = datetime.utcnow()
+    trade.close_date = datetime.now(timezone.utc)
     trade.is_open = False
+    Trade.commit()
 
-    telegram._profit(update=update, context=MagicMock())
+    context.args = [3]
+    telegram._profit(update=update, context=context)
     assert msg_mock.call_count == 1
     assert '*ROI:* Closed trades' in msg_mock.call_args_list[-1][0][0]
     assert ('∙ `0.00006217 BTC (6.20%) (0.62 \N{GREEK CAPITAL LETTER SIGMA}%)`'

--- a/tests/strategy/test_interface.py
+++ b/tests/strategy/test_interface.py
@@ -36,6 +36,10 @@ def test_returns_latest_signal(ohlcv_history):
     mocked_history = ohlcv_history.copy()
     mocked_history['sell'] = 0
     mocked_history['buy'] = 0
+    # Set tags in lines that don't matter to test nan in the sell line
+    mocked_history.loc[0, 'buy_tag'] = 'wrong_line'
+    mocked_history.loc[0, 'exit_tag'] = 'wrong_line'
+
     mocked_history.loc[1, 'sell'] = 1
 
     assert _STRATEGY.get_signal('ETH/BTC', '5m', mocked_history) == (False, True, None, None)


### PR DESCRIPTION
I've disabled rebuys for trades in hold to give us time to migrate over to the new logic adjust_position_enable logic.

This also means that right now forcebuys will not be automatically merged using the new logic, since by default forcebuys get a 0.1% hold. To prevent this, put forcebuy_hold_pct in your config and set it to 0. (**always test in dry mode first**)

**IMPORTANT**
Trades that have already been merged using the old /merge logic will be broken if you let them get handled by the new adjust_position_enable logic. The trade will get the wrong open_rate, probably because the merged orders are missing. **Make sure to put these trades on hold, or find another way to prevent the new logic to rebuy.** I've marked the old /merge logic as deprecated in /help and will notify as such whenever the command is used. It's ok to handle the old trades (if in hold), but stop using the old logic in the future. I will remove or hide it at some point once we've had enough time to move over.